### PR TITLE
Generalize skill to accept any free-form issue report and email agoodrich@scituatema.gov

### DIFF
--- a/alexa-skill/config/UI_Strings-Grid_view.csv
+++ b/alexa-skill/config/UI_Strings-Grid_view.csv
@@ -1,18 +1,18 @@
-﻿Id,Template,Notes
-welcome-new,"Welcome to Scituate. What issue would you like to report? You can say things like 'brown water.' For more examples, say 'help' at any time.",So I keep getting the tide charts and not this dev invocation when I test it.  Can we try Open Scituate Town Hall?  I assume others in town have the tide charts installed. 
+Id,Template,Notes
+welcome-new,"Welcome to Scituate. What issue would you like to report? You can say things like 'report brown water,' 'report a pothole,' 'report a downed tree,' or anything else. For more examples, say 'help' at any time.",
 error,"Sorry, I didn't understand that. Please try again or say 'help.'",
-help,"You can say things like 'brown water' or 'pothole.' To exit, say 'goodbye.'",
+help,"You can report any issue to the town. Just say what the problem is — for example, 'report there's flooding on my street' or 'report a broken streetlight.' To exit, say 'goodbye.'",
 goodbye,Goodbye,
 report-confirm,"OK, you want to report {issue-type} for {resident-address}. If that's correct, say ""send."" Otherwise, say ""cancel.""",
-report-sent,"Got it. Your report has been sent to the city. If you want to send another report later, just say 'Open Scituate' to start again.",
+report-sent,"Got it. Your report has been sent to the town. If you want to send another report later, just say 'Open Scituate' to start again.",
 email-from,Jim Grady <turingpolice@gmail.com>,
-email-to,jim@eonconnect.com,Separate multiple addresses by commans - this is the email to use:  publicworks@scituatema.gov <publicworks@scituatema.gov>;
-email-subject,Issue Report: {issue-type},
-email-text,Resident at {resident-address} has reported {issue-type},
-report-cancelled,"OK, your report has been cancelled. If you want to send a report later, just say 'Open Dev Scituate' to start again.",
+email-to,agoodrich@scituatema.gov,
+email-subject,Scituate Resident Report: {issue-type},
+email-text,A Scituate resident at {resident-address} has reported: {issue-type},
+report-cancelled,"OK, your report has been cancelled. If you want to send a report later, just say 'Open Scituate' to start again.",
 town-hall-hours,"Scituate town hall is open Monday, Wednesday and Thurday from 8:30 am to 4:45 pm, it is also open on Tuesday from 8:30am to 7:30pm, and Friday from 8:30am to 11:45am",
 veterans-agent,"The Scituate Veterans agent is Donald Knapp, his phone number is 781-545-8715",
 address-blank,"You've given me permission to access your street address, but you don't have any street address on file. Please open the Alexa app on your phone and go to device settings, then enter your address. When you're done, say ""Alexa, tell Scituate to send my report."" Or if you prefer, just say your street number and name now.",
 no-address-permission,"I need an address to send with the report. You can give me permission to access your address by going to the Alexa app on your phone now, or if you prefer, just say your street address now.",
-address-no-issue,"OK, I've got your address, but I need to know what issue you're reporting. You can say things like 'brown water.' For more examples, say 'help' at any time.",
+address-no-issue,"OK, I've got your address, but I need to know what issue you're reporting. Just say what the problem is — for example, 'brown water' or 'a pothole.'",
 ,,

--- a/alexa-skill/config/dev_skill/dev_phase/dialog_model.json
+++ b/alexa-skill/config/dev_skill/dev_phase/dialog_model.json
@@ -23,28 +23,20 @@
           "name": "ReportIssueIntent",
           "slots": [
             {
-              "name": "ReportPhrase",
-              "type": "ReportPhrase"
-            },
-            {
-              "name": "IssueType",
-              "type": "IssueType"
-            },
-            {
-              "name": "Location",
-              "type": "Location"
-            },
-            {
-              "name": "Address",
-              "type": "AMAZON.PostalAddress"
+              "name": "IssueDescription",
+              "type": "AMAZON.SearchQuery"
             }
           ],
           "samples": [
-            "{IssueType}",
-            "{ReportPhrase} {IssueType}",
-            "{ReportPhrase} {IssueType} {Location} near {Address}",
-            "{ReportPhrase} {IssueType} {Location} at {Address}",
-            "{ReportPhrase} {IssueType} {Location}"
+            "report {IssueDescription}",
+            "I want to report {IssueDescription}",
+            "I need to report {IssueDescription}",
+            "I'd like to report {IssueDescription}",
+            "we'd like to report {IssueDescription}",
+            "there is {IssueDescription}",
+            "there's {IssueDescription}",
+            "I have {IssueDescription}",
+            "we have {IssueDescription}"
           ]
         },
         {
@@ -97,99 +89,7 @@
           ]
         }
       ],
-      "types": [
-        {
-          "name": "IssueType",
-          "values": [
-            {
-              "id": "pothole",
-              "name": {
-                "value": "a pothole",
-                "synonyms": [
-                  "hole"
-                ]
-              }
-            },
-            {
-              "id": "brown-water",
-              "name": {
-                "value": "brown water",
-                "synonyms": [
-                  "gross water",
-                  "bad water"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "ReportPhrase",
-          "values": [
-            {
-              "id": "report",
-              "name": {
-                "value": "report",
-                "synonyms": [
-                  "we'd like to report",
-                  "i'd like to report"
-                ]
-              }
-            },
-            {
-              "id": "there-is",
-              "name": {
-                "value": "there is",
-                "synonyms": [
-                  "we have",
-                  "i have"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Location",
-          "values": [
-            {
-              "id": "street",
-              "name": {
-                "value": "street",
-                "synonyms": [
-                  "in the road",
-                  "on the road",
-                  "in the street",
-                  "on the street",
-                  "on our road",
-                  "on our street"
-                ]
-              }
-            },
-            {
-              "id": "faucet",
-              "name": {
-                "value": "faucet",
-                "synonyms": [
-                  "tap",
-                  "coming from our faucet",
-                  "coming out of our faucet"
-                ]
-              }
-            },
-            {
-              "id": "house",
-              "name": {
-                "value": "house",
-                "synonyms": [
-                  "in our home",
-                  "at our home",
-                  "in our house",
-                  "at our house"
-                ]
-              }
-            }
-          ]
-        }
-      ]
+      "types": []
     }
   }
 }

--- a/alexa-skill/config/prod_skill/dev_phase/dialog_model.json
+++ b/alexa-skill/config/prod_skill/dev_phase/dialog_model.json
@@ -23,28 +23,20 @@
           "name": "ReportIssueIntent",
           "slots": [
             {
-              "name": "ReportPhrase",
-              "type": "ReportPhrase"
-            },
-            {
-              "name": "IssueType",
-              "type": "IssueType"
-            },
-            {
-              "name": "Location",
-              "type": "Location"
-            },
-            {
-              "name": "Address",
-              "type": "AMAZON.PostalAddress"
+              "name": "IssueDescription",
+              "type": "AMAZON.SearchQuery"
             }
           ],
           "samples": [
-            "{IssueType}",
-            "{ReportPhrase} {IssueType}",
-            "{ReportPhrase} {IssueType} {Location} near {Address}",
-            "{ReportPhrase} {IssueType} {Location} at {Address}",
-            "{ReportPhrase} {IssueType} {Location}"
+            "report {IssueDescription}",
+            "I want to report {IssueDescription}",
+            "I need to report {IssueDescription}",
+            "I'd like to report {IssueDescription}",
+            "we'd like to report {IssueDescription}",
+            "there is {IssueDescription}",
+            "there's {IssueDescription}",
+            "I have {IssueDescription}",
+            "we have {IssueDescription}"
           ]
         },
         {
@@ -97,99 +89,7 @@
           ]
         }
       ],
-      "types": [
-        {
-          "name": "IssueType",
-          "values": [
-            {
-              "id": "pothole",
-              "name": {
-                "value": "a pothole",
-                "synonyms": [
-                  "hole"
-                ]
-              }
-            },
-            {
-              "id": "brown-water",
-              "name": {
-                "value": "brown water",
-                "synonyms": [
-                  "gross water",
-                  "bad water"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "ReportPhrase",
-          "values": [
-            {
-              "id": "report",
-              "name": {
-                "value": "report",
-                "synonyms": [
-                  "we'd like to report",
-                  "i'd like to report"
-                ]
-              }
-            },
-            {
-              "id": "there-is",
-              "name": {
-                "value": "there is",
-                "synonyms": [
-                  "we have",
-                  "i have"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Location",
-          "values": [
-            {
-              "id": "street",
-              "name": {
-                "value": "street",
-                "synonyms": [
-                  "in the road",
-                  "on the road",
-                  "in the street",
-                  "on the street",
-                  "on our road",
-                  "on our street"
-                ]
-              }
-            },
-            {
-              "id": "faucet",
-              "name": {
-                "value": "faucet",
-                "synonyms": [
-                  "tap",
-                  "coming from our faucet",
-                  "coming out of our faucet"
-                ]
-              }
-            },
-            {
-              "id": "house",
-              "name": {
-                "value": "house",
-                "synonyms": [
-                  "in our home",
-                  "at our home",
-                  "in our house",
-                  "at our house"
-                ]
-              }
-            }
-          ]
-        }
-      ]
+      "types": []
     }
   }
 }

--- a/alexa-skill/config/prod_skill/prod_phase/dialog_model.json
+++ b/alexa-skill/config/prod_skill/prod_phase/dialog_model.json
@@ -23,28 +23,20 @@
           "name": "ReportIssueIntent",
           "slots": [
             {
-              "name": "ReportPhrase",
-              "type": "ReportPhrase"
-            },
-            {
-              "name": "IssueType",
-              "type": "IssueType"
-            },
-            {
-              "name": "Location",
-              "type": "Location"
-            },
-            {
-              "name": "Address",
-              "type": "AMAZON.PostalAddress"
+              "name": "IssueDescription",
+              "type": "AMAZON.SearchQuery"
             }
           ],
           "samples": [
-            "{IssueType}",
-            "{ReportPhrase} {IssueType}",
-            "{ReportPhrase} {IssueType} {Location} near {Address}",
-            "{ReportPhrase} {IssueType} {Location} at {Address}",
-            "{ReportPhrase} {IssueType} {Location}"
+            "report {IssueDescription}",
+            "I want to report {IssueDescription}",
+            "I need to report {IssueDescription}",
+            "I'd like to report {IssueDescription}",
+            "we'd like to report {IssueDescription}",
+            "there is {IssueDescription}",
+            "there's {IssueDescription}",
+            "I have {IssueDescription}",
+            "we have {IssueDescription}"
           ]
         },
         {
@@ -97,99 +89,7 @@
           ]
         }
       ],
-      "types": [
-        {
-          "name": "IssueType",
-          "values": [
-            {
-              "id": "pothole",
-              "name": {
-                "value": "a pothole",
-                "synonyms": [
-                  "hole"
-                ]
-              }
-            },
-            {
-              "id": "brown-water",
-              "name": {
-                "value": "brown water",
-                "synonyms": [
-                  "gross water",
-                  "bad water"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "ReportPhrase",
-          "values": [
-            {
-              "id": "report",
-              "name": {
-                "value": "report",
-                "synonyms": [
-                  "we'd like to report",
-                  "i'd like to report"
-                ]
-              }
-            },
-            {
-              "id": "there-is",
-              "name": {
-                "value": "there is",
-                "synonyms": [
-                  "we have",
-                  "i have"
-                ]
-              }
-            }
-          ]
-        },
-        {
-          "name": "Location",
-          "values": [
-            {
-              "id": "street",
-              "name": {
-                "value": "street",
-                "synonyms": [
-                  "in the road",
-                  "on the road",
-                  "in the street",
-                  "on the street",
-                  "on our road",
-                  "on our street"
-                ]
-              }
-            },
-            {
-              "id": "faucet",
-              "name": {
-                "value": "faucet",
-                "synonyms": [
-                  "tap",
-                  "coming from our faucet",
-                  "coming out of our faucet"
-                ]
-              }
-            },
-            {
-              "id": "house",
-              "name": {
-                "value": "house",
-                "synonyms": [
-                  "in our home",
-                  "at our home",
-                  "in our house",
-                  "at our house"
-                ]
-              }
-            }
-          ]
-        }
-      ]
+      "types": []
     }
   }
 }

--- a/alexa-skill/handlers/ConfirmReportIntentHandler.js
+++ b/alexa-skill/handlers/ConfirmReportIntentHandler.js
@@ -77,7 +77,7 @@ class ConfirmReportIntentHandler extends SkillBaseIntentHandler {
         let sessionAttributes = this.attributesManager.getSessionAttributes();
         let address = sessionAttributes.issueAddress;
         if (!address) {
-            return this.templateRespond
+            return this.catchRespond('no-address', null);
         }
         let issueType = sessionAttributes.pendingIssue;
         if (!issueType) {

--- a/alexa-skill/handlers/ReportIssueIntentHandler.js
+++ b/alexa-skill/handlers/ReportIssueIntentHandler.js
@@ -5,7 +5,7 @@ class ReportIssueIntentHandler extends SkillBaseIntentHandler {
         return 'ReportIssueIntent';
     }
     process() {
-        let issueValue = this.slotValue('IssueType');
+        let issueValue = this.slotValue('IssueDescription');
         if (issueValue) {
             let sessionAttributes = this.attributesManager.getSessionAttributes();
             sessionAttributes.pendingIssue = issueValue;


### PR DESCRIPTION
Replaces the fixed IssueType slot with AMAZON.SearchQuery so residents can
report anything verbatim (brown water, potholes, downed trees, flooding, etc.)
instead of only recognized phrases. Updates email recipient to agoodrich@scituatema.gov,
refreshes welcome/help prompts, and fixes a missing function call in ConfirmReportIntentHandler.

https://claude.ai/code/session_01VDpTNnMqMPBtNwd1HL9gkw